### PR TITLE
PR#1: Launch and daemonise broker on user command

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ indent_style = space
 indent_size = 4
 end_of_line = lf
 charset = utf-8
-max_length = 120
+max_length = 80
 trim_trailing_whitespace = true
 insert_final_newline = true
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,10 +13,12 @@
     "prettier/prettier": [
       "error",
       {
-        "endOfLine": "lf",
+        "endOfLine": "auto",
         "singleQuote": true,
-        "tabWidth": 4
+        "tabWidth": 4,
+        "printWidth": 80
       }
-    ]
+    ],
+    "max-len": [1, 80, 4]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,6 @@
         "printWidth": 80
       }
     ],
-    "max-len": [1, 80, 4]
+    "max-len": [2, 80, 4]
   }
 }

--- a/bin/broker/index.js
+++ b/bin/broker/index.js
@@ -1,0 +1,36 @@
+// launch the dashboard broker as a daemon
+const cp = require('child_process');
+const utils = require('../utils');
+
+const launchBroker = (port) => {
+    if (!utils.validPortNumber(port)) {
+        throw new Error('Invalid port number.');
+    }
+
+    // TODO: Write port number to metadata file
+
+    // spawn the broker as a child process
+    const brokerProcess = cp.spawn(
+        process.execPath,
+        ['./bin/broker/server.js'],
+        {
+            detached: true,
+            stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+        }
+    );
+
+    // listen to emits by the broker regarding launch of server
+    brokerProcess.on('message', (data) => {
+        // log the message to the console
+        console.log(data.message);
+
+        // disconnect the IPC channel
+        brokerProcess.unref();
+        brokerProcess.disconnect();
+
+        // clean exit the process
+        process.exit(0);
+    });
+};
+
+module.exports = launchBroker;

--- a/bin/broker/index.js
+++ b/bin/broker/index.js
@@ -14,8 +14,10 @@ const launchBroker = (port) => {
         process.execPath,
         ['./bin/broker/server.js'],
         {
-            detached: true,
+            detached: true, // runs the child process independently of parent
             stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+            // disconnect all pipes except for ipc
+            // ['stdin', 'stdout', 'stderr', 'ipc']
         }
     );
 

--- a/bin/broker/server.js
+++ b/bin/broker/server.js
@@ -19,7 +19,7 @@ const server = app.listen(PORT, () => {
             status: 'success',
             message: `\nSUCCESS: Dashboard is up at port ${PORT}.`,
         });
-    } else if (process.env.NODE_ENV !== 'test') {
+    } else {
         // launched for dev: log success to console
         console.log(`Dashboard is running at port: ${PORT}`);
     }
@@ -43,7 +43,7 @@ server.on('error', (err) => {
             status: 'fail',
             message: serverError,
         });
-    } else if (process.env.NODE_ENV !== 'test') {
+    } else {
         // launched for dev: log error to console
         console.log(serverError);
     }

--- a/bin/broker/server.js
+++ b/bin/broker/server.js
@@ -6,6 +6,8 @@ const path = require('path');
 // port for the dashboard
 const PORT = 5001;
 
+// TODO: Get port number from metadata file
+
 // initialize express app
 const app = express();
 
@@ -13,7 +15,7 @@ const app = express();
 const server = app.listen(PORT, () => {
     if (process.hasOwnProperty('send')) {
         // launched as a daemon: emit success message to parent process
-        process?.send({
+        process.send({
             status: 'success',
             message: `\nSUCCESS: Dashboard is up at port ${PORT}.`,
         });
@@ -37,7 +39,7 @@ server.on('error', (err) => {
 
     if (process.hasOwnProperty('send')) {
         // launched as a daemon: emit failure message to parent process
-        process?.send({
+        process.send({
             status: 'fail',
             message: serverError,
         });

--- a/bin/broker/server.js
+++ b/bin/broker/server.js
@@ -19,7 +19,7 @@ const server = app.listen(PORT, () => {
             status: 'success',
             message: `\nSUCCESS: Dashboard is up at port ${PORT}.`,
         });
-    } else {
+    } else if (process.env.NODE_ENV !== 'test') {
         // launched for dev: log success to console
         console.log(`Dashboard is running at port: ${PORT}`);
     }
@@ -43,7 +43,7 @@ server.on('error', (err) => {
             status: 'fail',
             message: serverError,
         });
-    } else {
+    } else if (process.env.NODE_ENV !== 'test') {
         // launched for dev: log error to console
         console.log(serverError);
     }
@@ -57,5 +57,15 @@ const io = socket(server);
 
 // event listener for a new connection
 io.on('connection', (client) => {
-    console.log(client);
+    client.on('test-conn', (cb) => {
+        cb('hello world');
+    });
 });
+
+// terminate the express and socket.io server
+const terminateBroker = () => {
+    io.close();
+    server.close();
+};
+
+module.exports = terminateBroker;

--- a/bin/broker/server.js
+++ b/bin/broker/server.js
@@ -1,0 +1,59 @@
+// establish express + socket.io server
+const express = require('express');
+const socket = require('socket.io');
+const path = require('path');
+
+// port for the dashboard
+const PORT = 5001;
+
+// initialize express app
+const app = express();
+
+// create express server
+const server = app.listen(PORT, () => {
+    if (process.hasOwnProperty('send')) {
+        // launched as a daemon: emit success message to parent process
+        process?.send({
+            status: 'success',
+            message: `\nSUCCESS: Dashboard is up at port ${PORT}.`,
+        });
+    } else {
+        // launched for dev: log success to console
+        console.log(`Dashboard is running at port: ${PORT}`);
+    }
+});
+
+// error while creating express server
+server.on('error', (err) => {
+    let serverError = '\nERROR: Cannot start dashboard.';
+
+    // if port is busy, create custom error
+    if (err.code === 'EADDRINUSE') {
+        serverError += `\nPort ${PORT} is busy. 
+        Please try again on another port.`;
+    } else {
+        serverError += `\n${err.message}`;
+    }
+
+    if (process.hasOwnProperty('send')) {
+        // launched as a daemon: emit failure message to parent process
+        process?.send({
+            status: 'fail',
+            message: serverError,
+        });
+    } else {
+        // launched for dev: log error to console
+        console.log(serverError);
+    }
+});
+
+// serve static files - for the frontend
+app.use(express.static(path.join(__dirname, '..', 'frontend')));
+
+// setup socket.io server
+const io = socket(server);
+
+// event listener for a new connection
+io.on('connection', (client) => {
+    console.log(client);
+});

--- a/bin/frontend/index.html
+++ b/bin/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sample Newman Frontend</title>
+</head>
+<body>
+    <h1>Newman Dashboard 🚀</h1>
+</body>
+</html>

--- a/bin/utils/index.js
+++ b/bin/utils/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-    validatePortNumber: (portNo) => {
-        return !isNaN(portNo) && portNo >= 1 && portNo <= 65535;
+    validPortNumber: (portNo) => {
+        return !isNaN(portNo) && Number(portNo) >= 1 && Number(portNo) <= 65535;
     },
 };

--- a/bin/utils/index.js
+++ b/bin/utils/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+    validatePortNumber: (portNo) => {
+        return !isNaN(portNo) && portNo >= 1 && portNo <= 65535;
+    },
+};

--- a/index.js
+++ b/index.js
@@ -10,9 +10,16 @@ program
     .version(version, '-v, --version');
 
 program
-    .option('-p, --port <port>', 'Specify the port to launch the dashboard')
+    .option(
+        '-p, --port <port>',
+        'Specify the port to launch the dashboard',
+        '3000'
+    )
+    .action(() => {
+        // launch the broker as a daemon
+        const port = program.opts().port;
+        launchBroker(port);
+    })
     .parse(process.argv);
 
-// launch the broker as a daemon
-const port = program.opts().port || 3000;
-launchBroker(port);
+module.exports = program;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 const { Command } = require('commander');
 const program = new Command();
 const version = require('./package.json').version;
-const utils = require('./bin/utils');
+
+const launchBroker = require('./bin/broker/index');
 
 program
     .name('newman-dashboard')
@@ -11,3 +12,7 @@ program
 program
     .option('-p, --port <port>', 'Specify the port to launch the dashboard')
     .parse(process.argv);
+
+// launch the broker as a daemon
+const port = program.opts().port || 3000;
+launchBroker(port);

--- a/index.js
+++ b/index.js
@@ -16,9 +16,11 @@ program
         '3000'
     )
     .action(() => {
-        // launch the broker as a daemon
-        const port = program.opts().port;
-        launchBroker(port);
+        if (process.env.NODE_ENV !== 'test') {
+            // launch the broker as a daemon
+            const port = program.opts().port;
+            launchBroker(port);
+        }
     })
     .parse(process.argv);
 

--- a/index.js
+++ b/index.js
@@ -12,15 +12,24 @@ program
 program
     .option(
         '-p, --port <port>',
-        'Specify the port to launch the dashboard',
+        'Specify the port to launch the dashboard.',
         '3000'
     )
+    .option('-d, --daemonize', 'Run the server as a daemon.')
+    .option('-t, --test', 'Run the CLI without any actions for unit tests.')
     .action(() => {
-        if (process.env.NODE_ENV !== 'test') {
+        if (program.opts().test) {
+            return;
+        }
+
+        if (program.opts().daemonize) {
             // launch the broker as a daemon
             const port = program.opts().port;
             launchBroker(port);
+            return;
         }
+
+        require('./bin/broker/server');
     })
     .parse(process.argv);
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+const { Command } = require('commander');
+const program = new Command();
+const version = require('./package.json').version;
+const utils = require('./bin/utils');
+
+program
+    .name('newman-dashboard')
+    .addHelpCommand(false)
+    .version(version, '-v, --version');
+
+program
+    .option('-p, --port <port>', 'Specify the port to launch the dashboard')
+    .parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-promise": "^5.1.0",
     "prettier": "^2.3.0"
+  },
+  "dependencies": {
+    "commander": "^7.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "commander": "^7.2.0",
     "express": "^4.17.1",
-    "socket.io": "^4.1.2"
+    "socket.io": "^4.1.2",
+    "socket.io-client": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A WebUI companion for Newman to control, view and debug runs.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dashboard:dev": "node ./bin/broker/server.js"
   },
   "keywords": [
     "newman",
@@ -34,6 +35,8 @@
     "prettier": "^2.3.0"
   },
   "dependencies": {
-    "commander": "^7.2.0"
+    "commander": "^7.2.0",
+    "express": "^4.17.1",
+    "socket.io": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A WebUI companion for Newman to control, view and debug runs.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha",
     "dashboard:dev": "node ./bin/broker/server.js"
   },
   "keywords": [
@@ -25,6 +25,7 @@
     "node": ">= 10"
   },
   "devDependencies": {
+    "chai": "^4.3.4",
     "editorconfig": "^0.15.3",
     "eslint": "^7.27.0",
     "eslint-config-prettier": "^8.3.0",
@@ -32,6 +33,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-promise": "^5.1.0",
+    "mocha": "^8.4.0",
     "prettier": "^2.3.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A WebUI companion for Newman to control, view and debug runs.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha",
+    "test": "npm run test:lint && mocha",
+    "test:lint": "eslint *.js",
     "dashboard:dev": "node ./bin/broker/server.js"
   },
   "keywords": [

--- a/test/broker-launch.test.js
+++ b/test/broker-launch.test.js
@@ -1,6 +1,5 @@
 const expect = require('chai').expect;
 const io = require('socket.io-client');
-process.env.NODE_ENV = 'test';
 
 describe('Broker connection handling', () => {
     let client, terminateBroker;

--- a/test/broker-launch.test.js
+++ b/test/broker-launch.test.js
@@ -1,0 +1,25 @@
+const expect = require('chai').expect;
+const io = require('socket.io-client');
+process.env.NODE_ENV = 'test';
+
+describe('Broker connection handling', () => {
+    let client, terminateBroker;
+
+    before((done) => {
+        terminateBroker = require('../bin/broker/server.js');
+        client = io('http://localhost:5001/');
+        client.on('connect', done);
+    });
+
+    after(() => {
+        client.close();
+        terminateBroker();
+    });
+
+    it('should emit events', (done) => {
+        client.emit('test-conn', (arg) => {
+            expect(arg).to.equal('hello world');
+            done();
+        });
+    });
+});

--- a/test/cli-report-parsing.test.js
+++ b/test/cli-report-parsing.test.js
@@ -1,0 +1,32 @@
+const expect = require('chai').expect;
+let cli;
+
+const version = require('../package.json').version;
+
+describe('CLI port number parsing', () => {
+    beforeEach(function () {
+        // delete require cache to use program instance for consecutive runs.
+        delete require.cache[require.resolve('./cli/mockCLI.js')];
+        cli = require('./cli/mockCLI');
+    });
+
+    it('should use the default port number of 3000', (done) => {
+        cli('node index.js', (err, opts) => {
+            expect(err).to.be.null;
+            expect(opts).to.eql({
+                port: '3000',
+            });
+            done();
+        });
+    });
+
+    it('should use the specified port number', (done) => {
+        cli('node index.js --port 5000', (err, opts) => {
+            expect(err).to.be.null;
+            expect(opts).to.eql({
+                port: '5000',
+            });
+            done();
+        });
+    });
+});

--- a/test/cli-report-parsing.test.js
+++ b/test/cli-report-parsing.test.js
@@ -1,4 +1,6 @@
 const expect = require('chai').expect;
+process.env.NODE_ENV = 'test';
+
 let cli;
 
 const version = require('../package.json').version;

--- a/test/cli-report-parsing.test.js
+++ b/test/cli-report-parsing.test.js
@@ -1,22 +1,13 @@
 const expect = require('chai').expect;
-process.env.NODE_ENV = 'test';
-
-let cli;
-
-const version = require('../package.json').version;
+const cli = require('./cli/mockCLI');
 
 describe('CLI port number parsing', () => {
-    beforeEach(function () {
-        // delete require cache to use program instance for consecutive runs.
-        delete require.cache[require.resolve('./cli/mockCLI.js')];
-        cli = require('./cli/mockCLI');
-    });
-
     it('should use the default port number of 3000', (done) => {
         cli('node index.js', (err, opts) => {
             expect(err).to.be.null;
             expect(opts).to.eql({
                 port: '3000',
+                test: true,
             });
             done();
         });
@@ -27,6 +18,7 @@ describe('CLI port number parsing', () => {
             expect(err).to.be.null;
             expect(opts).to.eql({
                 port: '5000',
+                test: true,
             });
             done();
         });

--- a/test/cli/mockCLI.js
+++ b/test/cli/mockCLI.js
@@ -1,0 +1,14 @@
+const program = require('../../index');
+
+const cli = (args, callback) => {
+    const argv = args.split(' ');
+    try {
+        program.parse(argv);
+        return callback(null, program.opts());
+    } catch (err) {
+        console.log(err);
+        return callback(err);
+    }
+};
+
+module.exports = cli;

--- a/test/cli/mockCLI.js
+++ b/test/cli/mockCLI.js
@@ -1,7 +1,9 @@
 const program = require('../../index');
 
 const cli = (args, callback) => {
-    const argv = args.split(' ');
+    let argv = args.split(' ');
+    argv.push('--test');
+
     try {
         program.parse(argv);
         return callback(null, program.opts());


### PR DESCRIPTION
Code for *Step 1: Setting up and launching the broker and dashboard on user command*

### Work Done 👨‍💻
- Setup project skeleton and directory structure
- Setup eslint, prettier and ```.editorconfig``` for consistent styling.
- Commander for the CLI and ```argv``` parsing.
- Creating a server built on express and socket.io
- Launching the server as a daemon using the native NodeJS ```child_process``` module

Command to start the daemon:
```
node ./index.js --port 5000
```
### Notes 📒

1. ```port``` is an optional parameter, if not used defaults to 3000.
2. Currently port number is hard coded as ```5001```. Will add functionality to change it when we implement the metadata files.
3. There is currently, no support to terminate the daemon using the frontend, so you would have to terminate it manually.
       - For windows users - terminates all independent nodeJS processes
         ``` 
            taskkill /F /IM node.exe
        ```
       - For Linux
       ``` 
            sudo killall -9 node
        ```

### Help With ❔

- Deciding on the error message body and how to deliver them.