### PR TITLE
add: listeners on reporter for executing requests on newman

### DIFF
--- a/dashboard/frontend/main.js
+++ b/dashboard/frontend/main.js
@@ -33,6 +33,15 @@ const clickPauseButton = (value) => {
     }
 };
 
+const clickAbortButton = (value) => {
+    // get process id of the process on which pause button has been clicked
+    const id = value.parentElement.getAttribute('data-process-id');
+
+    socket.emit('abort', {
+        id,
+    });
+};
+
 // HTML for adding a new element to the runs
 const newProcessHTML = (data) => {
     return `<div 
@@ -46,6 +55,13 @@ const newProcessHTML = (data) => {
         >
             Pause
         </button>
+        <button
+            class="abort-button"
+            onclick="clickAbortButton(this)"
+            id="abort-${data.id}"
+        >
+            Abort
+        </button>
         <div>
             <p class="exec-run-command">${data.command}</p>
             <p class="exec-run-date">${data.startTime}</p>
@@ -56,4 +72,12 @@ const newProcessHTML = (data) => {
 // for adding a new process to the frontend
 socket.on('start', (data) => {
     execRuns.innerHTML = execRuns.innerHTML + newProcessHTML(data);
+});
+
+socket.on('pause', (data) => {
+    document.getElementById(`pause-${data.id}`).innerText = 'Resume';
+});
+
+socket.on('resume', (data) => {
+    document.getElementById(`pause-${data.id}`).innerText = 'Pause';
 });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "newman-dashboard",
+  "name": "newman-reporter-dashboard",
   "version": "0.0.1",
   "description": "A WebUI companion for Newman to control, view and debug runs.",
   "main": "index.js",

--- a/reporter/index.js
+++ b/reporter/index.js
@@ -11,11 +11,23 @@ const socket = io('http://localhost:5001/', {
 
 const events = require('./lib/events')(socket, id);
 
-module.exports = function (newman, options, collectionOptions) {
+module.exports = function (newman, options, collectionOptions, commands) {
     newman.on('start', events.handleStart);
     newman.on('done', events.handleDone);
 
     newman.on('resume', events.handleResume);
     newman.on('pause', events.handlePause);
     newman.on('abort', events.handleAbort);
+
+    socket.on('pause', (data) => {
+        commands.pause();
+    });
+
+    socket.on('resume', () => {
+        commands.resume();
+    });
+
+    socket.on('abort', () => {
+        commands.abort();
+    });
 };

--- a/reporter/lib/events.js
+++ b/reporter/lib/events.js
@@ -1,26 +1,26 @@
+const utils = require('./utils');
+
 module.exports = (socket, id) => {
     return {
         handleStart: (err, args) => {
-            if (err) {
-                // return if any error on starting the run
-                return;
-            }
+            if (err) return socket.close();
 
-            socket.emit('start', {
-                id,
-            });
+            socket.emit('start', utils.generateStartData(process.argv, id));
         },
 
         handleDone: (err, args) => {
-            if (err) return;
+            if (err) return socket.close();
 
             socket.emit('done', {
                 id,
             });
+
+            // close the client
+            socket.close();
         },
 
         handlePause: (err, args) => {
-            if (err) return;
+            if (err) return socket.close();
 
             socket.emit('pause', {
                 id,
@@ -28,7 +28,7 @@ module.exports = (socket, id) => {
         },
 
         handleResume: (err, args) => {
-            if (err) return;
+            if (err) return socket.close();
 
             socket.emit('resume', {
                 id,
@@ -36,7 +36,7 @@ module.exports = (socket, id) => {
         },
 
         handleAbort: (err, args) => {
-            if (err) return;
+            if (err) return socket.close();
 
             socket.emit('abort', {
                 id,

--- a/reporter/lib/utils/index.js
+++ b/reporter/lib/utils/index.js
@@ -1,0 +1,14 @@
+module.exports = {
+    generateStartData: (argv, id) => {
+        if (!argv || !id) return {};
+
+        const runIndex = argv.indexOf('run');
+        const command = runIndex > -1 && argv.slice(runIndex).join(' ');
+
+        return {
+            id,
+            command,
+            startTime: Date.now(),
+        };
+    },
+};

--- a/test/unit/reporter/lib/events.test.js
+++ b/test/unit/reporter/lib/events.test.js
@@ -10,6 +10,7 @@ describe('Reporter events', () => {
     beforeEach('setup mocks and spies', () => {
         socket = {
             emit: sinon.spy(),
+            close: sinon.spy(),
         };
     });
 
@@ -40,13 +41,18 @@ describe('Reporter events', () => {
             expect(socket.emit.calledOnce).to.be.true;
             expect(socket.emit.firstCall.args).to.have.lengthOf(2);
             expect(socket.emit.firstCall.args[0]).to.equal('start');
-            expect(socket.emit.firstCall.args[1]).to.eql({ id: 'abc' });
+            expect(socket.emit.firstCall.args[1]).to.haveOwnProperty('id');
+            expect(socket.emit.firstCall.args[1]).to.haveOwnProperty('command');
+            expect(socket.emit.firstCall.args[1]).to.haveOwnProperty(
+                'startTime'
+            );
         });
 
         it('should handle error', () => {
             handleStart(new Error('error in start'));
 
             expect(socket.emit.called).to.be.false;
+            expect(socket.close.called).to.be.true;
         });
     });
 
@@ -74,6 +80,7 @@ describe('Reporter events', () => {
             handleDone(new Error('error in done'));
 
             expect(socket.emit.called).to.be.false;
+            expect(socket.close.called).to.be.true;
         });
     });
 
@@ -101,6 +108,7 @@ describe('Reporter events', () => {
             handlePause(new Error('error in pause'));
 
             expect(socket.emit.called).to.be.false;
+            expect(socket.close.called).to.be.true;
         });
     });
 
@@ -128,6 +136,7 @@ describe('Reporter events', () => {
             handleResume(new Error('error in resume'));
 
             expect(socket.emit.called).to.be.false;
+            expect(socket.close.called).to.be.true;
         });
     });
 
@@ -155,6 +164,7 @@ describe('Reporter events', () => {
             handleAbort(new Error('error in abort'));
 
             expect(socket.emit.called).to.be.false;
+            expect(socket.close.called).to.be.true;
         });
     });
 });


### PR DESCRIPTION
Completes all necessary requirements for creating the MVP

1. Parses `process.argv` to send the newman command to the frontend.
2. Executes the `run.pause()` and other control commands exposed by newman to the reporters
3. Refactors tests to test the dashboard request handling by the reporter
4. Adds `abort` button to the frontend for issuing an abort request