### PR TITLE
fix: UI edge cases of handling test errors

### DIFF
--- a/frontend/actions/index.js
+++ b/frontend/actions/index.js
@@ -72,10 +72,16 @@ const mountSockets = (store) => {
     socket.on('run-event', (data) => {
         const run = store.find(data.id);
         run.addEvent(data);
+
+        if(data.err) {
+            run.setInterrupted();
+        }
     });
 
     socket.on('run-stats', (data) => {
         const run = store.find(data.id);
+        if(run.isPaused()) return;
+        
         run.addRunStats(data);
     });
 

--- a/frontend/actions/index.js
+++ b/frontend/actions/index.js
@@ -61,6 +61,9 @@ const mountSockets = (store) => {
           
         const run = store.find(data.id);
 
+        // keep status as aborted
+        if(run.isAborted()) return;
+
         run.setFinished();
     });
 
@@ -74,12 +77,15 @@ const mountSockets = (store) => {
         run.addEvent(data);
 
         if(data.err) {
+            // mark run as errored
             run.setInterrupted();
         }
     });
 
     socket.on('run-stats', (data) => {
         const run = store.find(data.id);
+
+        // ignore the run stats if it is paused
         if(run.isPaused()) return;
         
         run.addRunStats(data);

--- a/frontend/actions/index.js
+++ b/frontend/actions/index.js
@@ -84,9 +84,6 @@ const mountSockets = (store) => {
 
     socket.on('run-stats', (data) => {
         const run = store.find(data.id);
-
-        // ignore the run stats if it is paused
-        if(run.isPaused()) return;
         
         run.addRunStats(data);
     });

--- a/frontend/components/EmptyRuns.js
+++ b/frontend/components/EmptyRuns.js
@@ -1,7 +1,7 @@
-const EmptyRuns = () => {
+const EmptyRuns = ({ message }) => {
     return (
         <div className="mt-44 text-center">
-            {/* <p className="text-center text-xl text-gray-500 italic">No runs to show :(</p> */}
+            {message && <p className="text-center text-xl text-gray-500 italic">{message}</p>}
             <div className="mt-4 shadow px-5 py-5 rounded">
                 <p className="text-bold text-gray-500 italic text-lg" >Install newman dashboard</p>
                 <p className="font-mono bg-gray-100 text-gray-500 rounded-l rounded-r my-4 text-xl text-center">npm i -g newman-reporter-dashboard</p>

--- a/frontend/components/RunData.js
+++ b/frontend/components/RunData.js
@@ -1,6 +1,6 @@
-import { observer } from 'mobx-react';
-import StatusRibbon from './StatusRibbon';
-import RunEvent from './RunEvent';
+import { observer } from "mobx-react";
+import StatusRibbon from "./StatusRibbon";
+import RunEvent from "./RunEvent";
 
 const RunData = observer(({ run }) => {
     const parsedTime = new Date(run.startTime).toLocaleTimeString();
@@ -24,15 +24,23 @@ const RunData = observer(({ run }) => {
                     <div className="flex">
                         <div className="mr-8 text-center">
                             <p className="font-mono text-3xl">
-                                {run.averageCpuUsage() || 0}%
+                                {run.getCpuUsage() || 0}%
                             </p>
-                            <p className="text-sm italic">CPU</p>
+                            <p className="text-sm italic">
+                                {run.isActive() || run.isPaused()
+                                    ? "CPU Usage"
+                                    : "Average CPU Usage"}
+                            </p>
                         </div>
                         <div className="text-center">
                             <p className="font-mono text-3xl">
-                                {run.averageMemoryUsage() || 0}MB
+                                {run.getMemoryUsage() || 0}MB
                             </p>
-                            <p className="text-sm italic">Memory</p>
+                            <p className="text-sm italic">
+                                {run.isActive() || run.isPaused()
+                                    ? "Memory Usage"
+                                    : "Average Memory Usage"}
+                            </p>
                         </div>
                     </div>
                 </div>

--- a/frontend/components/RunEvent.js
+++ b/frontend/components/RunEvent.js
@@ -40,7 +40,16 @@ const BeforeRequest = ({ arg, err }) => {
 };
 
 const Request = ({ arg, err }) => {
-    const bgColor = arg.response.code === 200 ? 'text-green-500' : 'text-yellow-200';
+    let code, responseTime;
+    if (arg.hasOwnProperty('response') && arg.response.hasOwnProperty('code')) {
+        code = arg.response.code;
+        responseTime = arg.response.responseTime;
+    } else {
+        code = 'ERR';
+        responseTime = 0;
+    }
+
+    const bgColor = code === 200 ? 'text-green-500' : 'text-red-500';
 
     return (
         <div className="flex ml-8 my-2 text-sm">
@@ -49,10 +58,10 @@ const Request = ({ arg, err }) => {
                     "mr-2 bg-gray-100 px-2 rounded-l rounded-r " + bgColor
                 }
             >
-                {arg.response.code}
+                {code}
             </p>
             <p className="text-gray-400 bg-gray-100 px-2 rounded-l rounded-r">
-                {arg.response.responseTime} ms
+                {responseTime} ms
             </p>
         </div>
     );

--- a/frontend/pages/run/[id].js
+++ b/frontend/pages/run/[id].js
@@ -5,6 +5,7 @@ import runStore from '../../state/stores';
 
 import RunData from "../../components/RunData";
 import Header from "../../components/Header";
+import EmptyRuns from '../../components/EmptyRuns';
 
 const RunDetails = observer((props) => {
     const router = useRouter();
@@ -15,7 +16,13 @@ const RunDetails = observer((props) => {
     return (
         <>
             <Header />
-            {!!run ? <RunData run={run} /> : <p>Invalid Run</p>}
+            {!!run ? (
+                <RunData run={run} />
+            ) : (
+                <div className="flex flex-col items-center">
+                    <EmptyRuns message="No run found." />
+                </div>
+            )}
         </>
     );
 });

--- a/frontend/state/models/run.js
+++ b/frontend/state/models/run.js
@@ -49,6 +49,11 @@ export default class RunModel {
     }
 
     @computed
+    isActive() {
+        return this.status === RUN_STATUS.ACTIVE;
+    }
+
+    @computed
     isAborted() {
         return this.status === RUN_STATUS.ABORTED;
     }
@@ -117,7 +122,16 @@ export default class RunModel {
     }
 
     @computed
-    averageMemoryUsage() {
+    getMemoryUsage() {
+        // show live memory stats while run is active
+        if (this.isActive() || this.isPaused()) {
+            let currMemory = this.memoryUsage[this.memoryUsage.length - 1] / 1e6;
+            let roundedMemory = Math.round((currMemory + Number.EPSILON) * 100) / 100;
+
+            return roundedMemory;
+        }
+
+        // show average memory stats if run is complete
         let totalMemory = 0;
         this.memoryUsage.forEach((memory) => {
             totalMemory += memory;
@@ -132,7 +146,16 @@ export default class RunModel {
     }
 
     @computed
-    averageCpuUsage() {
+    getCpuUsage() {
+        // show live CPU stats while run is active
+        if(this.isActive() || this.isPaused()) {
+            let currCpu = this.cpuUsage[this.cpuUsage.length - 1];
+            let roundedCpu = Math.round((currCpu + Number.EPSILON) * 100) / 100;
+
+            return roundedCpu;
+        }
+
+        // show average CPU stats if run is complete
         let totalCpu = 0;
         this.cpuUsage.forEach((cpu) => {
             totalCpu += cpu;

--- a/frontend/state/models/run.js
+++ b/frontend/state/models/run.js
@@ -48,6 +48,11 @@ export default class RunModel {
         return this.status === RUN_STATUS.FINISHED;
     }
 
+    @computed
+    isAborted() {
+        return this.status === RUN_STATUS.ABORTED;
+    }
+
     @action
     _init(data) {
         this.command = data.command;


### PR DESCRIPTION
Fixes some UI edge cases:
1. Marks the run status as `error` whenever an error is generated by Newman, previously it used to keep showing `running` even when the run ended.
2. Does not update the CPU/Memory stats when the run gets paused.